### PR TITLE
Close mobile menu when navigating

### DIFF
--- a/components/Nav/Links/index.jsx
+++ b/components/Nav/Links/index.jsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { slide, scale } from "../animation";
 
-export default function Index({ data, isActive, setSelectedIndicator }) {
+export default function Index({ data, isActive, setSelectedIndicator, onNavigate }) {
   const { label, href, index, key } = data;
 
   return (
@@ -23,7 +23,16 @@ export default function Index({ data, isActive, setSelectedIndicator }) {
         animate={isActive ? "open" : "closed"}
         className={styles.indicator}
       ></motion.div>
-      <Link href={href}>{label}</Link>
+      <Link
+        href={href}
+        onClick={() => {
+          if (onNavigate) {
+            onNavigate();
+          }
+        }}
+      >
+        {label}
+      </Link>
     </motion.div>
   );
 }

--- a/components/Nav/index.jsx
+++ b/components/Nav/index.jsx
@@ -10,7 +10,7 @@ import { NAV_LINKS } from "@/constants";
 import Image from "next/image";
 import Link from "next/link";
 
-export default function Index({ deviceType }) {
+export default function Index({ deviceType, onClose }) {
   const pathname = usePathname();
   const [selectedIndicator, setSelectedIndicator] = useState(pathname);
 
@@ -38,6 +38,7 @@ export default function Index({ deviceType }) {
               data={{ ...data, index }}
               isActive={selectedIndicator === data.href}
               setSelectedIndicator={setSelectedIndicator}
+              onNavigate={onClose}
             />
           ))}
         </div>

--- a/components/Navbar/Navbar.jsx
+++ b/components/Navbar/Navbar.jsx
@@ -17,12 +17,11 @@ function Navbar({ deviceType }) {
   const pathname = usePathname();
   const button = useRef(null);
 
-  useEffect(
-    (isActive) => {
-      isActive && setIsActive(false);
-    },
-    [pathname, isActive]
-  );
+  useEffect(() => {
+    if (isActive) {
+      setIsActive(false);
+    }
+  }, [pathname, isActive]);
 
   useLayoutEffect(() => {
     gsap.registerPlugin(ScrollTrigger);
@@ -141,7 +140,9 @@ function Navbar({ deviceType }) {
         </Rounded>
       </div>
       <AnimatePresence mode="wait">
-        {isActive && <Nav deviceType={deviceType} />}
+        {isActive && (
+          <Nav deviceType={deviceType} onClose={() => setIsActive(false)} />
+        )}
       </AnimatePresence>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "spocale_lp",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- reset the navbar hamburger state when the route changes so the menu closes after navigation
- allow the overlay menu to accept a close handler and trigger it from each navigation link click
- specify Node.js 22.x in the engines field so deployments target the supported runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d53ca3f99c832fb4e55873cc62842c